### PR TITLE
fixed graceful shutdown

### DIFF
--- a/server.go
+++ b/server.go
@@ -59,6 +59,9 @@ func (s *Server) RunServer() error {
 	for {
 		// accept connection from client
 		conn, err := s.Listener.Accept()
+		if conn == nil {
+			return nil
+		}
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
if the listener was gracefully Closed, `conn` is `nil`, there was no `return` for this case so the next `for` loop failed because `s.Listener.Accept()` is not working on a Closed Listener

without returning `nil` we get an `err` returned: `accept tcp [::]:12345: use of closed network connection"`